### PR TITLE
Add Rule5_Watermark example jupyter notebook

### DIFF
--- a/notebooks/Rule5_Watermark.ipynb
+++ b/notebooks/Rule5_Watermark.ipynb
@@ -1,0 +1,411 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demonstrating Rule 5: Using Watermark to Record Dependencies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Introduction\n",
+    "### Installation and Using Watermark\n",
+    "### Helpful References\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction\n",
+    "After reading [\"Ten simple rules for writing and sharing computational analyses in Jupyter Notebooks\"](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1007007), it was clear how important it is to record the dependencies for your Jupyter Notebooks in order for others to be able to reproduce the results you created. Using **Rule 5** enables others to have a clear understanding of your Jupyter environment at the time your notebook was created."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Rule 5: \"Record dependencies\"\n",
+    "\n",
+    "> Rerunning your analysis in the future will require accessing not only your code but also any module or library that your code relied on. As is best practice across computational science, manage your dependencies using a package or environment manager like pip or Conda. These enable you to download modules and libraries, specify the version of each you want to use in your analysis, and even generate files such as Conda’s environment.yml or pip’s requirements.txt that concisely describe all of your dependencies. These files can be used by tools such as Binder or Docker to generate a “container” that other researchers can use to reproduce your analysis using the same versions of every module and library as you did. Always conduct your work in an environment created only from these dependencies to ensure you do not add undocumented dependencies.\n",
+    "\n",
+    "> As an extra precaution in notebooks, you can explicitly print out your dependencies using a notebook extension such as [watermark](https://github.com/rasbt/watermark). Listing the versions of critical dependencies in the notebook itself (best done at the bottom) will ensure that, if used in isolation from its environment, the notebook still contains critical information to help readers run it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Goal of this Notebook\n",
+    "In this notebook, I will demonstrate the following portion of **Rule 5**:\n",
+    "> **As an extra precaution in notebooks, you can explicitly print out your dependencies using a notebook extension such as [watermark](https://github.com/rasbt/watermark). Listing the versions of critical dependencies in the notebook itself (best done at the bottom) will ensure that, if used in isolation from its environment, the notebook still contains critical information to help readers run it.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I will do this by:\n",
+    "1. installing watermark\n",
+    "2. creating multiple watermarks \n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Installation and Using Watermark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**The watermark line magic can be installed two ways:**\n",
+    "1. pip install watermark\n",
+    "2. pip install -e git+https://github.com/rasbt/watermark#egg=watermark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If installation is successful, then you can load the **watermark** magic extension into your notebook with the following code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext watermark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To generate a basic watermark in your notebook, run the following code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-11-25T01:12:13-05:00\n",
+      "\n",
+      "CPython 3.7.3\n",
+      "IPython 7.4.0\n",
+      "\n",
+      "compiler   : MSC v.1915 64 bit (AMD64)\n",
+      "system     : Windows\n",
+      "release    : 10\n",
+      "machine    : AMD64\n",
+      "processor  : Intel64 Family 6 Model 58 Stepping 9, GenuineIntel\n",
+      "CPU cores  : 8\n",
+      "interpreter: 64bit\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The watermark magic function has many optional arguments. They are listed below:\n",
+    "\n",
+    "-a AUTHOR, --author AUTHOR \n",
+    "                        prints author name\n",
+    "\n",
+    "-d,  --date            prints current date as YYYY-mm-dd\n",
+    "\n",
+    "-n,  --datename        prints date with abbrv. day and month names\n",
+    "\n",
+    "-t,  --time            prints current time as HH-MM-SS\n",
+    "\n",
+    "-i,  --iso8601         prints the combined date and time including the time\n",
+    "                       zone in the ISO 8601 standard with UTC offset\n",
+    "\n",
+    "-z,  --timezone        appends the local time zone\n",
+    "\n",
+    "-u,  --updated         appends a string \"Last updated: \"\n",
+    "\n",
+    "-c CUSTOM_TIME, --custom_time CUSTOM_TIME\n",
+    "                       prints a valid strftime() string\n",
+    "\n",
+    "-v,  --python          prints Python and IPython version\n",
+    "\n",
+    "-p PACKAGES, --packages PACKAGES\n",
+    "                       prints versions of specified Python modules and packages\n",
+    "\n",
+    "-h,  --hostname        prints the host name\n",
+    "\n",
+    "-m,  --machine         prints system and machine info\n",
+    "\n",
+    "-g,  --githash         prints current Git commit hash\n",
+    "\n",
+    "-r,  --gitrepo         prints current Git remote address\n",
+    "\n",
+    "-b,  --gitbranch       prints the current Git branch (new in v1.6)\n",
+    "\n",
+    "-iv, --iversion        print name and version of all imported packages      \n",
+    "\n",
+    "-w,  --watermark       prints the current version of watermark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Printing date (-n), time (-t) and timezone (-z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mon Nov 25 2019 01:26:53 Eastern Standard Time\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark -n -t -z"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print date (-n), time (-t), and author (-a) \n",
+    "\n",
+    "(note: watermark forces an output order of Author Date Time regardless of input order)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ten Rules Mon Nov 25 2019 01:27:12\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark -t -n -a \"Ten Rules\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print Python and IPython versions (-v) and machine info (-m)\n",
+    "\n",
+    "(note: watermark includes this information within the default %watermark command with no arguments)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPython 3.7.3\n",
+      "IPython 7.4.0\n",
+      "\n",
+      "compiler   : MSC v.1915 64 bit (AMD64)\n",
+      "system     : Windows\n",
+      "release    : 10\n",
+      "machine    : AMD64\n",
+      "processor  : Intel64 Family 6 Model 58 Stepping 9, GenuineIntel\n",
+      "CPU cores  : 8\n",
+      "interpreter: 64bit\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark -v -m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print package versions for pandas, numpy, matplotlib using (-p)\n",
+    "\n",
+    "(note: after the -p argument you must pass in the names of the modules in a comma separated format with no spaces"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pandas 0.24.2\n",
+      "numpy 1.16.2\n",
+      "matplotlib 3.0.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark -p pandas,numpy,matplotlib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print package versions for pandas, numpy, matplotlib using (-iv). The (-iv) method record the version of any module/package loaded into the environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "matplotlib 3.0.3\n",
+      "pandas     0.24.2\n",
+      "numpy      1.16.2\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark -iv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "import matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "matplotlib 3.0.3\n",
+      "pandas     0.24.2\n",
+      "numpy      1.16.2\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%watermark -iv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the previous cell, you can see that matplotlib, pandas, and numpy versions were recorded even though pandas was imported three cells before while numpy and matplotlib were imported the cell before.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Helpful References\n",
+    "For more information on using the watermark magic function within Jupyter Notebooks, the following resource is **very helpful**:\n",
+    "\n",
+    "https://github.com/rasbt/watermark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION


Hello,
I came across the "Ten simple rules for writing and sharing computational analyses in Jupyter Notebooks" during my class with the University of Michigan this month. Because of how important I feel Rule 5 is to making sure notebook dependencies are recorded, I created a jupyter notebook showing different ways you can use the watermark magic function to record version levels. I included a couple examples showing how to add authors, dates, and time stamps as well.

Let me know if you would like me to change anything. I plan on adding a few more notebook examples for other rules as well so that the example library can grow. Excellent work getting this started!

Anthony